### PR TITLE
JOBS-391: Tag 가로 크기 스타일 버그

### DIFF
--- a/src/components/molecules/Tag/index.module.scss
+++ b/src/components/molecules/Tag/index.module.scss
@@ -9,10 +9,10 @@
   align-items: center;
   justify-content: center;
 
-  padding: 1px 8px;
   border-radius: 4px;
 
   font-weight: 600;
+  line-height: 0;
   white-space: pre;
 
   &:has(.close-button) {
@@ -21,17 +21,17 @@
 }
 
 .size-14 {
-  height: 14px;
+  padding: 1px 8px;
 
   font-size: $SMALL3X;
 }
 .size-18 {
-  height: 18px;
+  padding: 3px 8px;
 
   font-size: $SMALL3X;
 }
 .size-26 {
-  height: 26px;
+  padding: 6px 8px;
 
   font-size: $SMALL;
 }

--- a/src/components/molecules/Tag/index.tsx
+++ b/src/components/molecules/Tag/index.tsx
@@ -29,7 +29,7 @@ export const Tag = ({
   const [display, setDisplay] = useState(true);
 
   return display ? (
-    <div
+    <span
       className={`${styles['tag-container']} ${styles[`size-${size}`]} ${
         styles[color.replaceAll('/', '_')]
       } ${className}`}
@@ -48,6 +48,6 @@ export const Tag = ({
           icon={<X size="13px" className={styles['close-icon']} />}
         />
       ) : null}
-    </div>
+    </span>
   ) : null;
 };


### PR DESCRIPTION
## Review Point 📝
[[JOBS-391](https://codestates.atlassian.net/browse/JOBS-391)] Tag의 상위 태그의 가로 너비에 맞게 Tag의 가로 사이즈가 늘어나는 버그 해결


**변경 사항**
- 인라인 태그로 변경(div -> span)
- 태그의 너비, 높이 결정 방식 수정(height -> padding)

[JOBS-391]: https://codestates.atlassian.net/browse/JOBS-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ