### PR TITLE
fix: Selectbox,Searchbox inputStyle의 font속성이 안먹히는 이슈

### DIFF
--- a/src/components/atoms/Input/InputWrap.module.scss
+++ b/src/components/atoms/Input/InputWrap.module.scss
@@ -21,8 +21,6 @@
 
   background-color: libs.$WHITE;
 
-  font-size: libs.$NORMAL;
-
   transition: box-shadow 0.3s, background-color 0.3s;
 
   &.border-radius-4 {

--- a/src/components/atoms/Input/InputWrap.module.scss
+++ b/src/components/atoms/Input/InputWrap.module.scss
@@ -21,6 +21,13 @@
 
   background-color: libs.$WHITE;
 
+  @include libs.font-size;
+  @layer {
+    & {
+      font-size: libs.$NORMAL;
+    }
+  }
+
   transition: box-shadow 0.3s, background-color 0.3s;
 
   &.border-radius-4 {

--- a/src/components/atoms/Input/index.module.scss
+++ b/src/components/atoms/Input/index.module.scss
@@ -12,8 +12,15 @@
   text-align: start;
 
   transition: color 0.3s;
-  @include libs.font-size;
-  @include libs.font-weight;
+
+  @layer {
+    & {
+      @include libs.font-size;
+
+      @include libs.font-weight;
+    }
+  }
+
   &::placeholder {
     color: libs.$BLUISH-GRAY-300;
   }

--- a/src/components/molecules/Selectbox/index.stories.tsx
+++ b/src/components/molecules/Selectbox/index.stories.tsx
@@ -56,6 +56,7 @@ const meta: Meta<typeof Selectbox> = {
     },
     description: '테스트',
     readOnly: false,
+    cancelable: true,
   },
 };
 

--- a/src/components/molecules/Selectbox/index.tsx
+++ b/src/components/molecules/Selectbox/index.tsx
@@ -28,6 +28,7 @@ export interface SelectboxProps<
   inputStyle?: Pick<InputWrapProps, 'borderRadius' | 'size' | 'width'> &
     UseTypographyClassNameParams;
   description?: InputWrapProps['description'];
+  cancelable?: boolean;
 }
 
 export const Selectbox = <
@@ -52,6 +53,7 @@ export const Selectbox = <
   optionStyle,
   description,
   readOnly,
+  cancelable = true,
 }: SelectboxProps<_ValidOptionValue, _Multiple>) => {
   const [opened, setOpened] = useState(false);
 
@@ -107,6 +109,7 @@ export const Selectbox = <
           <ChevronDown />
         </Input.Wrap>
         <Options
+          cancelable={cancelable}
           opened={opened}
           options={options}
           multiple={multiple}

--- a/src/components/organisms/DropdownTag/index.module.scss
+++ b/src/components/organisms/DropdownTag/index.module.scss
@@ -1,7 +1,11 @@
 .dropdown-tag-container {
   position: relative;
 
-  width: fit-content;
+  @layer {
+    & {
+      width: fit-content;
+    }
+  }
 }
 
 .options {

--- a/src/components/organisms/DropdownTag/index.module.scss
+++ b/src/components/organisms/DropdownTag/index.module.scss
@@ -1,7 +1,7 @@
 .dropdown-tag-container {
   position: relative;
 
-  width: 300px;
+  width: fit-content;
 }
 
 .options {


### PR DESCRIPTION
## Review Point 📝
- 구두로 말씀드린 Selectbox, Searchbox에 inputStyle로 font속성을 넣었을때 안먹히는 이슈
- Dropdown Tag를 켠 후 dropdown 외부를 클릭했음에도 어느 부분에서는 dropdown이 꺼지지 않는 이슈
