### PR TITLE
[DTL-428] Textbox, Textarea 컴포넌트의 props 개방

### DIFF
--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -15,22 +15,12 @@ import styles from './index.module.scss';
 export type { InputWrapProps } from './InputWrap';
 
 export interface InputProps<T extends InputType = 'text'>
-  extends Pick<
+  extends Omit<
       React.DetailedHTMLProps<
         React.InputHTMLAttributes<HTMLInputElement>,
         HTMLInputElement
       >,
-      | 'placeholder'
-      | 'onFocus'
-      | 'id'
-      | 'onClick'
-      | 'onBlur'
-      | 'ref'
-      | 'name'
-      | 'className'
-      | 'readOnly'
-      | 'maxLength'
-      | 'minLength'
+      'onChange' | 'size'
     >,
     UseTypographyClassNameParams {
   type?: T;

--- a/src/components/molecules/Textarea/index.tsx
+++ b/src/components/molecules/Textarea/index.tsx
@@ -18,12 +18,12 @@ import styles from './index.module.scss';
 import { Tag } from '../Tag';
 
 export interface TextareaProps
-  extends Pick<
+  extends Omit<
       DetailedHTMLProps<
         TextareaHTMLAttributes<HTMLTextAreaElement>,
         HTMLTextAreaElement
       >,
-      'placeholder' | 'id' | 'readOnly' | 'minLength' | 'maxLength'
+      'onChange' | 'onClick' | 'disabled'
     >,
     Omit<LabelWithInputProps, 'inputStyle'> {
   onChange?: (value?: string) => void;

--- a/src/components/molecules/Textbox/index.tsx
+++ b/src/components/molecules/Textbox/index.tsx
@@ -17,23 +17,7 @@ import styles from './index.module.scss';
 type TextboxType = Exclude<InputType, 'button'>;
 
 export interface TextboxProps<T extends TextboxType = 'text'>
-  extends Pick<
-    InputProps<T>,
-    | 'value'
-    | 'onChange'
-    | 'type'
-    | 'placeholder'
-    | 'disabled'
-    | 'onFocus'
-    | 'ref'
-    | 'id'
-    | 'onClick'
-    | 'className'
-    | 'onBlur'
-    | 'readOnly'
-    | 'maxLength'
-    | 'minLength'
-  > {
+  extends InputProps<T> {
   label?: string;
   unit?: React.ReactNode;
   validation?: ValidateHandler<TextboxProps<T>['value']>;
@@ -71,6 +55,7 @@ export const Textbox = <T extends TextboxType = 'text'>({
   requireMessage,
   maxLength,
   minLength,
+  ...props
 }: TextboxProps<T>) => {
   const [value, setValue] = useSubscribedState(originalValue);
 
@@ -101,6 +86,7 @@ export const Textbox = <T extends TextboxType = 'text'>({
         readOnly={readOnly}
       >
         <Input
+          {...props}
           fontSize={inputStyle?.fontSize}
           fontWeight={inputStyle?.fontWeight}
           onClick={onClick}


### PR DESCRIPTION
## Review Point 📝
기존에 닫혀있던 input props들을 개방해서 사용할 수 있도록 수정

```tsx
// As-Is 사용 불가
<Textbox onKeyDown={...} />


// To-Be input과 관련된 모든 props 전달 가능
<Textbox 
  onKeyDown={...} 
  onKeyUp={...}
  ...
/>
```